### PR TITLE
fixing token_wise rotation size when different from value size

### DIFF
--- a/fake_quant/rotation_utils.py
+++ b/fake_quant/rotation_utils.py
@@ -294,7 +294,7 @@ class QKRotationWrapper(torch.nn.Module):
         
 
         if self.k_groupsize == -1: #token-wise quantization
-            token_wise_k = k.transpose(1, 2).reshape(-1, self.config.hidden_size)
+            token_wise_k = k.transpose(1, 2).reshape(-1, self.config.hidden_size * self.config.num_key_value_heads / self.config.num_attention_heads)
             self.k_quantizer.find_params(token_wise_k)
             k = self.k_quantizer(token_wise_k).reshape((bsz, seq_len, num_heads, head_dim)).transpose(1, 2).to(q)
         else: #head-wise quantization


### PR DESCRIPTION
Using the right value of hidden size for the k projection.